### PR TITLE
Fixed the 'ArrayIndexOutOfBoundsException' triggered in TrackListActivity.java file

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -364,10 +364,15 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
         }
 
         if (itemId == R.id.list_context_menu_edit) {
-            Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
-                    .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
-            startActivity(intent);
-            return true;
+            if (trackIds.length > 0) {
+                Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
+                        .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
+                startActivity(intent);
+                return true;
+            } else {
+                Toast.makeText(this, "No track selected.", Toast.LENGTH_SHORT).show();
+                return false;
+            }
         }
 
         if (itemId == R.id.list_context_menu_delete) {


### PR DESCRIPTION
Fixed the 'ArrayIndexOutOfBoundsException' triggered in TrackListActivity.java file

**Describe the pull request**
This pull request addresses an issue in TrackListActivity.java where accessing a collection could result in an ArrayIndexOutOfBoundsException. The fix ensures safe access to the collection, preventing potential crashes.

The solution involves checking the array length before performing the edit functionality.

**Link to the the issue**
Resolves : https://github.com/haniehst/OpenTracksW25_Group5/issues/7


