### PR TITLE
Refactor: Eliminate code duplication in sensor stats tests

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/data/CustomContentProviderUtilsTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/data/CustomContentProviderUtilsTest.java
@@ -1121,31 +1121,9 @@ public class CustomContentProviderUtilsTest {
     @Test
     public void testGetSensorStats_withManualResume() {
         // given
-        /*
-         * time elapsed    hr      cadence     power       track type
-         * 0               140     75          250         -1
-         * 2               148     80          300         0
-         * 1               150     82          325         0
-         * 3               174     88          400         0
-         * 20              127     54          175         -2
-         * 3               160     90          275         0
-         * 7               155     85          280         0
-         * 3               150     90          267         0
-         * 3               170     90          240         0
-         * 2               155     84          295         1
-         */
         Instant start = Instant.now();
         TestSensorDataUtil sensorDataUtil = new TestSensorDataUtil();
-        sensorDataUtil.add(start, 140f, 75f, 250f, TrackPoint.Type.SEGMENT_START_AUTOMATIC);
-        sensorDataUtil.add(start.plus(2, ChronoUnit.SECONDS), 148f, 80f, 300f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(3, ChronoUnit.SECONDS), 150f, 82f, 325f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(6, ChronoUnit.SECONDS), 174f, 88f, 400f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(26, ChronoUnit.SECONDS), 127f, 54f, 175f, TrackPoint.Type.SEGMENT_START_MANUAL);
-        sensorDataUtil.add(start.plus(29, ChronoUnit.SECONDS), 160f, 90f, 275f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(36, ChronoUnit.SECONDS), 155f, 85f, 280f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(39, ChronoUnit.SECONDS), 150f, 90f, 267f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(42, ChronoUnit.SECONDS), 170f, 90f, 240f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(44, ChronoUnit.SECONDS), 155f, 84f, 295f, TrackPoint.Type.SEGMENT_END_MANUAL);
+        addSensorDataWithManualResume(start, sensorDataUtil);
 
         Track.Id trackId = new Track.Id(start.toEpochMilli());
         Track track = TestDataUtil.createTrack(trackId);
@@ -1166,31 +1144,9 @@ public class CustomContentProviderUtilsTest {
     @Test
     public void testGetSensorStats_withStartAutomatic() {
         // given
-        /*
-         * time elapsed    hr      cadence     power       track type
-         * 0               140     75          250         -1
-         * 2               148     80          300         0
-         * 1               150     82          325         0
-         * 3               174     88          400         0
-         * 20              127     54          175         -1
-         * 3               160     90          275         0
-         * 7               155     85          280         0
-         * 3               150     90          267         0
-         * 3               170     90          240         0
-         * 2               155     84          295         1
-         */
         Instant start = Instant.now();
         TestSensorDataUtil sensorDataUtil = new TestSensorDataUtil();
-        sensorDataUtil.add(start, 140f, 75f, 250f, TrackPoint.Type.SEGMENT_START_AUTOMATIC);
-        sensorDataUtil.add(start.plus(2, ChronoUnit.SECONDS), 148f, 80f, 300f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(3, ChronoUnit.SECONDS), 150f, 82f, 325f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(6, ChronoUnit.SECONDS), 174f, 88f, 400f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(26, ChronoUnit.SECONDS), 127f, 54f, 175f, TrackPoint.Type.SEGMENT_START_AUTOMATIC);
-        sensorDataUtil.add(start.plus(29, ChronoUnit.SECONDS), 160f, 90f, 275f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(36, ChronoUnit.SECONDS), 155f, 85f, 280f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(39, ChronoUnit.SECONDS), 150f, 90f, 267f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(42, ChronoUnit.SECONDS), 170f, 90f, 240f, TrackPoint.Type.TRACKPOINT);
-        sensorDataUtil.add(start.plus(44, ChronoUnit.SECONDS), 155f, 84f, 295f, TrackPoint.Type.SEGMENT_END_MANUAL);
+        addSensorDataWithStartAutomatic(start, sensorDataUtil);
 
         Track.Id trackId = new Track.Id(start.toEpochMilli());
         Track track = TestDataUtil.createTrack(trackId);
@@ -1206,6 +1162,32 @@ public class CustomContentProviderUtilsTest {
         assertEquals(sensorStatistics.avgCadence().getRPM(), stats.avgCadence, 0f);
         assertEquals(sensorStatistics.maxCadence().getRPM(), stats.maxCadence, 0f);
         assertEquals(sensorStatistics.avgPower().getW(), stats.avgPower, 0f);
+    }
+
+    private void addSensorDataWithManualResume(Instant start, TestSensorDataUtil sensorDataUtil) {
+        sensorDataUtil.add(start, 140f, 75f, 250f, TrackPoint.Type.SEGMENT_START_AUTOMATIC);
+        sensorDataUtil.add(start.plus(2, ChronoUnit.SECONDS), 148f, 80f, 300f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(3, ChronoUnit.SECONDS), 150f, 82f, 325f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(6, ChronoUnit.SECONDS), 174f, 88f, 400f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(26, ChronoUnit.SECONDS), 127f, 54f, 175f, TrackPoint.Type.SEGMENT_START_MANUAL);
+        sensorDataUtil.add(start.plus(29, ChronoUnit.SECONDS), 160f, 90f, 275f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(36, ChronoUnit.SECONDS), 155f, 85f, 280f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(39, ChronoUnit.SECONDS), 150f, 90f, 267f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(42, ChronoUnit.SECONDS), 170f, 90f, 240f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(44, ChronoUnit.SECONDS), 155f, 84f, 295f, TrackPoint.Type.SEGMENT_END_MANUAL);
+    }
+
+    private void addSensorDataWithStartAutomatic(Instant start, TestSensorDataUtil sensorDataUtil) {
+        sensorDataUtil.add(start, 140f, 75f, 250f, TrackPoint.Type.SEGMENT_START_AUTOMATIC);
+        sensorDataUtil.add(start.plus(2, ChronoUnit.SECONDS), 148f, 80f, 300f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(3, ChronoUnit.SECONDS), 150f, 82f, 325f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(6, ChronoUnit.SECONDS), 174f, 88f, 400f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(26, ChronoUnit.SECONDS), 127f, 54f, 175f, TrackPoint.Type.SEGMENT_START_AUTOMATIC);
+        sensorDataUtil.add(start.plus(29, ChronoUnit.SECONDS), 160f, 90f, 275f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(36, ChronoUnit.SECONDS), 155f, 85f, 280f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(39, ChronoUnit.SECONDS), 150f, 90f, 267f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(42, ChronoUnit.SECONDS), 170f, 90f, 240f, TrackPoint.Type.TRACKPOINT);
+        sensorDataUtil.add(start.plus(44, ChronoUnit.SECONDS), 155f, 84f, 295f, TrackPoint.Type.SEGMENT_END_MANUAL);
     }
 
     private void testGetSensorStats_randomData(int totalPoints, boolean withStartSegments) {


### PR DESCRIPTION
This pull request refactors the test methods related to sensor statistics in the CustomContentProviderUtilsTest class. The primary goal of this refactor is to eliminate code duplication and improve maintainability by consolidating repeated logic into reusable helper methods.

issue: https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/26


**Changes:**

- Refactor Test Methods: Both testGetSensorStats_withManualResume and testGetSensorStats_withStartAutomatic contained identical logic for setting up sensor data. This redundancy was removed by moving the common sensor data setup into two separate helper methods (addSensorDataWithManualResume and addSensorDataWithStartAutomatic).
- Improved Maintainability: By creating helper methods, we reduce code duplication, making it easier to maintain and extend the tests in the future.
- Cleaner Test Code: The test methods are now more focused on testing the functionality, with the data setup logic abstracted away.

**Reason for Changes:**
The tests had redundant logic for setting up sensor data, which made the code harder to maintain and read. By refactoring the tests, we ensure that future changes to the data setup only need to be made in one place.

**Testing:**

- Ran all unit tests to ensure that the tests still pass after the refactor.
- Verified that both refactored tests (testGetSensorStats_withManualResume and testGetSensorStats_withStartAutomatic) still pass with the updated helper methods.

**ScreenShot:**

![SS_caseStudy2_!](https://github.com/user-attachments/assets/e75ce4b0-9922-4df4-831f-f89b56f153a7)

![SS_caseStudy2](https://github.com/user-attachments/assets/8892d1ae-6986-4381-b98f-b23ecc8b8e0f)
