### PR TITLE
Refactored duplicate speed and pace logic

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/AggregatedStatisticsAdapter.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/aggregatedStatistics/AggregatedStatisticsAdapter.java
@@ -85,36 +85,38 @@ public class AggregatedStatisticsAdapter extends RecyclerView.Adapter<RecyclerVi
             setCommonValues(aggregatedStatistic);
 
             SpeedFormatter formatter = SpeedFormatter.Builder().setUnit(unitSystem).setReportSpeedOrPace(reportSpeed).build(context);
-            {
-                Pair<String, String> parts = formatter.getSpeedParts(aggregatedStatistic.getTrackStatistics().getAverageMovingSpeed());
-                viewBinding.aggregatedStatsAvgRate.setText(parts.first);
-                viewBinding.aggregatedStatsAvgRateUnit.setText(parts.second);
-                viewBinding.aggregatedStatsAvgRateLabel.setText(context.getString(R.string.stats_average_moving_speed));
-            }
 
-            {
-                Pair<String, String> parts = formatter.getSpeedParts(aggregatedStatistic.getTrackStatistics().getMaxSpeed());
-                viewBinding.aggregatedStatsMaxRate.setText(parts.first);
-                viewBinding.aggregatedStatsMaxRateUnit.setText(parts.second);
-                viewBinding.aggregatedStatsMaxRateLabel.setText(context.getString(R.string.stats_max_speed));
-            }
+            updateSpeedOrPace(formatter, aggregatedStatistic, true);
         }
 
         public void setPace(AggregatedStatistics.AggregatedStatistic aggregatedStatistic) {
             setCommonValues(aggregatedStatistic);
 
             SpeedFormatter formatter = SpeedFormatter.Builder().setUnit(unitSystem).setReportSpeedOrPace(reportSpeed).build(context);
-            {
-                Pair<String, String> parts = formatter.getSpeedParts(aggregatedStatistic.getTrackStatistics().getAverageMovingSpeed());
-                viewBinding.aggregatedStatsAvgRate.setText(parts.first);
-                viewBinding.aggregatedStatsAvgRateUnit.setText(parts.second);
+
+            updateSpeedOrPace(formatter, aggregatedStatistic, false);
+        }
+
+        private void updateSpeedOrPace(SpeedFormatter formatter, AggregatedStatistics.AggregatedStatistic aggregatedStatistic,
+                                       boolean isSpeed) {
+            // Handles both Speed and Pace updates using a single method
+            Pair<String, String> avgParts = formatter.getSpeedParts(aggregatedStatistic.getTrackStatistics().getAverageMovingSpeed());
+            viewBinding.aggregatedStatsAvgRate.setText(avgParts.first);
+            viewBinding.aggregatedStatsAvgRateUnit.setText(avgParts.second);
+
+            if (isSpeed) {
+                viewBinding.aggregatedStatsAvgRateLabel.setText(context.getString(R.string.stats_average_moving_speed));
+            } else {
                 viewBinding.aggregatedStatsAvgRateLabel.setText(context.getString(R.string.stats_average_moving_pace));
             }
 
-            {
-                Pair<String, String> parts = formatter.getSpeedParts(aggregatedStatistic.getTrackStatistics().getMaxSpeed());
-                viewBinding.aggregatedStatsMaxRate.setText(parts.first);
-                viewBinding.aggregatedStatsMaxRateUnit.setText(parts.second);
+            Pair<String, String> maxParts = formatter.getSpeedParts(aggregatedStatistic.getTrackStatistics().getMaxSpeed());
+            viewBinding.aggregatedStatsMaxRate.setText(maxParts.first);
+            viewBinding.aggregatedStatsMaxRateUnit.setText(maxParts.second);
+
+            if (isSpeed) {
+                viewBinding.aggregatedStatsMaxRateLabel.setText(context.getString(R.string.stats_max_speed));
+            } else {
                 viewBinding.aggregatedStatsMaxRateLabel.setText(R.string.stats_fastest_pace);
             }
         }


### PR DESCRIPTION
This pull request resolves Issue #47 by refactoring the duplicate code found in AggregatedStatisticsAdapter.java. The duplication was identified in the setSpeed and setPace method at lines 84 and 103 respectively.

Link to the the issue: https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/47

Before Refactoring:

![Screenshot 2025-03-16 at 1 00 48 AM](https://github.com/user-attachments/assets/bcab987d-918b-4c39-9520-13926c9a91e4)

After Refactoring: 

![Screenshot 2025-03-16 at 1 06 20 AM](https://github.com/user-attachments/assets/508268c7-c56f-415c-9c27-b3e8d7bc81e9)

