### PR TITLE
Fix code duplication in GenericStatisticsViewHolder.java

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
@@ -165,7 +165,13 @@ public abstract class GenericStatisticsViewHolder extends StatisticViewHolder<St
         }
     }
 
-    public static class AverageMovingPace extends GenericStatisticsViewHolder {
+    public static class AveragePaceVH extends GenericStatisticsViewHolder {
+
+        private final boolean isMovingPace;
+
+        protected AveragePaceVH(boolean isMovingPace) {
+            this.isMovingPace = isMovingPace;
+        }
 
         @Override
         public void onChanged(UnitSystem unitSystem, RecordingData data) {
@@ -178,24 +184,22 @@ public abstract class GenericStatisticsViewHolder extends StatisticViewHolder<St
 
             getBinding().statsValue.setText(valueAndUnit.first);
             getBinding().statsUnit.setText(valueAndUnit.second);
-            getBinding().statsDescriptionMain.setText(getContext().getString(R.string.stats_average_moving_pace));
+            getBinding().statsDescriptionMain.setText(
+                    getContext().getString(isMovingPace ? R.string.stats_average_moving_pace : R.string.stats_average_pace)
+            );
         }
     }
 
-    public static class AveragePace extends GenericStatisticsViewHolder {
+    // Subclasses for map-based instantiation
+    public static class AverageMovingPace extends AveragePaceVH {
+        public AverageMovingPace() {
+            super(true);
+        }
+    }
 
-        @Override
-        public void onChanged(UnitSystem unitSystem, RecordingData data) {
-            SpeedFormatter speedFormatterSpeed = SpeedFormatter.Builder()
-                    .setUnit(unitSystem)
-                    .setReportSpeedOrPace(false)
-                    .build(getContext());
-
-            Pair<String, String> valueAndUnit = speedFormatterSpeed.getSpeedParts(data.getTrackStatistics().getAverageMovingSpeed());
-
-            getBinding().statsValue.setText(valueAndUnit.first);
-            getBinding().statsUnit.setText(valueAndUnit.second);
-            getBinding().statsDescriptionMain.setText(getContext().getString(R.string.stats_average_pace));
+    public static class AveragePace extends AveragePaceVH {
+        public AveragePace() {
+            super(false);
         }
     }
 


### PR DESCRIPTION
Changes made to remove clone detection in `GenericStaticViewHolder.java`

1. Merged AverageMovingPace and AveragePace into a single class named AveragePaceVH.
2. Added a constructor parameter to differentiate between "Average Moving Pace" and "Average Pace".

As there is a mapping usage in `src/main/java/de/dennisguse/opentracks/viewmodels/Mapping.java`,  two subclasses of the merged class (AveragePaceVH) are created so they can be referenced in the map without requiring arguments.

```
m.put(context.getString(R.string.stats_custom_layout_average_moving_pace_key), GenericStatisticsViewHolder.AverageMovingPace::new);
m.put(context.getString(R.string.stats_custom_layout_average_pace_key), GenericStatisticsViewHolder.AveragePace::new);
```

Both classes now reuse the same logic, reducing redundancy while maintaining clarity.

Resolves: https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/40