### PR TITLE
Refactored duplicate trackpoints

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/stats/TrackStatisticsUpdaterTest.java
@@ -180,30 +180,34 @@ public class TrackStatisticsUpdaterTest {
         assertEquals(59.18, subject.getTrackStatistics().getTotalDistance().toM(), 0.01);
     }
 
+    private void addTrackPointsToSubject(TrackStatisticsUpdater subject, List<TrackPoint> trackPoints) {
+        subject.addTrackPoints(trackPoints);
+    }
+
     @Test
     public void addTrackPoint_maxSpeed_multiple_segments() {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
         assertEquals(Speed.of(0f), subject.getTrackStatistics().getMaxSpeed());
 
-        subject.addTrackPoints(List.of(
+        List<TrackPoint> firstSegment = List.of(
                 new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(0)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1))
-                        .setSpeed(Speed.of(2f)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2))
-                        .setSpeed(Speed.of(2f)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1)).setSpeed(Speed.of(2f)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2)).setSpeed(Speed.of(2f)),
                 new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochSecond(4))
-        ));
+        );
+
+        addTrackPointsToSubject(subject, firstSegment);
         assertEquals(Speed.of(2f), subject.getTrackStatistics().getMaxSpeed());
 
         // when
-        subject.addTrackPoints(List.of(
+        List<TrackPoint> secondSegment = List.of(
                 new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(5)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(6))
-                        .setSpeed(Speed.of(1f)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(7))
-                        .setSpeed(Speed.of(1f)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(6)).setSpeed(Speed.of(1f)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(7)).setSpeed(Speed.of(1f)),
                 new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochSecond(8))
-        ));
+        );
+
+        addTrackPointsToSubject(subject, secondSegment);
 
         // then
         assertEquals(Speed.of(2f), subject.getTrackStatistics().getMaxSpeed());
@@ -241,31 +245,25 @@ public class TrackStatisticsUpdaterTest {
         TrackStatisticsUpdater subject = new TrackStatisticsUpdater();
 
         // when
-        subject.addTrackPoints(List.of(
+        List<TrackPoint> trackPoints = List.of(
                 new TrackPoint(TrackPoint.Type.SEGMENT_START_MANUAL, Instant.ofEpochSecond(0)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1))
-                        .setSensorDistance(Distance.of(10)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2))
-                        .setSensorDistance(Distance.of(10)),
-
-                new TrackPoint(TrackPoint.Type.IDLE, Instant.ofEpochSecond(30))
-                        .setSensorDistance(Distance.ofKilometer(1)),
-                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(40))
-                        .setHeartRate(50),
-                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(45))
-                        .setHeartRate(50),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(50))
-                        .setSensorDistance(Distance.of(10)),
-                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(55))
-                        .setSensorDistance(Distance.of(10)),
-
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(1)).setSensorDistance(Distance.of(10)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(2)).setSensorDistance(Distance.of(10)),
+                new TrackPoint(TrackPoint.Type.IDLE, Instant.ofEpochSecond(30)).setSensorDistance(Distance.ofKilometer(1)),
+                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(40)).setHeartRate(50),
+                new TrackPoint(TrackPoint.Type.TRACKPOINT, Instant.ofEpochSecond(45)).setHeartRate(50),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(50)).setSensorDistance(Distance.of(10)),
+                new TrackPoint(0, 0, Altitude.WGS84.of(0), Instant.ofEpochSecond(55)).setSensorDistance(Distance.of(10)),
                 new TrackPoint(TrackPoint.Type.SEGMENT_END_MANUAL, Instant.ofEpochSecond(60))
-        ));
+        );
+
+        addTrackPointsToSubject(subject, trackPoints);
 
         // then
         assertEquals(Duration.ofSeconds(40), subject.getTrackStatistics().getMovingTime());
         assertEquals(Distance.of(1040), subject.getTrackStatistics().getTotalDistance());
     }
+
 
     @Test
     public void addTrackPoint_idle_remain_idle() {


### PR DESCRIPTION
This pull request refactors duplicate code in TrackStatisticsUpdaterTest.java by extracting repeated logic into a helper method. The duplicated code, responsible for adding track points and asserting statistics, was found in:

Line 186 → addTrackPoint_maxSpeed_multiple_segments()
Line 241 → addTrackPoint_idle_withDistance()
By introducing a reusable helper method, we reduce redundancy and improve maintainability in the test suite.


Link to the the issue: https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/64

Refactored Code:

![Screenshot 2025-03-17 at 2 21 31 AM](https://github.com/user-attachments/assets/44e07be8-d4f3-42c4-a651-01e65864b633)

![Screenshot 2025-03-17 at 2 22 23 AM](https://github.com/user-attachments/assets/405ea67a-6e28-4593-880b-328e8fa57ce3)



