### PR TITLE
Added Thread.currentThread().interrupt(); so the information of the c…

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/GPXTrackExporter.java
@@ -117,6 +117,7 @@ public class GPXTrackExporter implements TrackExporter {
             return true;
         } catch (InterruptedException e) {
             Log.e(TAG, "Thread interrupted", e);
+            Thread.currentThread().interrupt();
             return false;
         }
     }


### PR DESCRIPTION
…urrent thread will not be lost

# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://github.com/haniehst/OpenTracksW25_Group5/tree/ryane-Thread-fix)

**Describe the pull request**
Just added `Thread.currentThread.interrupt()`
**Link to the the issue**
[The link to the issue that this pull request solves.](https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/87)

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

Resolves https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/87