### PR TITLE
Fix SQL injection in ExportActivity by URL validation

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
@@ -169,6 +169,16 @@ public class ExportActivity extends AppCompatActivity implements ExportService.E
         if (savedInstanceState == null) {
             autoConflict = ConflictResolutionStrategy.CONFLICT_NONE;
             setProgress();
+
+            // validate the URL before using
+            if (directoryUri == null || !"content".equals(directoryUri.getScheme())) {
+                runOnUiThread(() -> {
+                    Toast.makeText(this, "Invalid URI provided", Toast.LENGTH_SHORT).show();
+                    finish();
+                });
+                return;
+            }
+
             new Thread(() -> {
                 directoryFiles = ExportUtils.getAllFiles(ExportActivity.this, documentFile.getUri());
                 runOnUiThread(() -> {


### PR DESCRIPTION
**Describe the pull request**
To address the potential SQL injection vulnerability flagged by Snyk, we added a runtime validation of the URI object before it is passed into ExportUtils.getAllFiles(...). While the flagged usage was a false positive (as the query is made through Android's ContentResolver, not raw SQL), this additional validation ensures that only well-formed content:// URIs are used, reducing the risk of malformed or malicious input being passed through.

**Resolves**
https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/91

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).


