### PR TITLE
Fix: Removed SQL Injection (SECSQLITEA) in CustomContentProvider.java Line 270

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
+++ b/src/main/java/de/dennisguse/opentracks/data/CustomContentProvider.java
@@ -267,7 +267,18 @@ public int delete(@NonNull Uri url, String where, String[] selectionArgs) {
                 }
                 case TRACKPOINTS_BY_TRACKID -> {
                     queryBuilder.setTables(TrackPointsColumns.TABLE_NAME);
-                    queryBuilder.appendWhere(TrackPointsColumns.TRACKID + " IN (" + TextUtils.join(SQL_LIST_DELIMITER, ContentProviderUtils.parseTrackIdsFromUri(url)) + ")");
+                    String[] trackIds = ContentProviderUtils.parseTrackIdsFromUri(url);
+                    StringBuilder whereClause = new StringBuilder(TrackPointsColumns.TRACKID + " IN (");
+                    for (int i = 0; i < trackIds.length; i++) {
+                        whereClause.append("?");
+                        if (i < trackIds.length - 1) {
+                            whereClause.append(", ");
+                        }
+                    }
+                    whereClause.append(")");
+                    queryBuilder.appendWhere(whereClause.toString());
+                    selectionArgs = trackIds;
+
                 }
                 case TRACKS -> {
                     if (projection != null && Arrays.asList(projection).contains(TracksColumns.MARKER_COUNT)) {


### PR DESCRIPTION
### Tool Used:
SpotBugs with FindSecBugs plugin

### Vulnerability Type:
SECSQLITEA (SQL Injection)

### File:
`CustomContentProvider.java`

### Line:
270

### Description:
Replaced vulnerable usage of `TextUtils.join(...)` in raw SQL string construction with a parameterized clause using placeholders (`?`) to prevent SQL injection.

### Fixed Code:
The `appendWhere` clause was rewritten to dynamically generate placeholders and use `selectionArgs`.

### Issue Reference:
Fixes #92

### Build and Analysis:
 Build tested successfully with `gradlew clean build`  
 SpotBugs confirmed issue is no longer present attached the image below

![Screenshot 2025-04-01 194005](https://github.com/user-attachments/assets/35909938-41cf-40c1-9986-1e5c4e6b58ab)
![Screenshot 2025-04-01 193839](https://github.com/user-attachments/assets/4406ef04-cb59-4f27-a120-cfe63fabdd10)


