### PR TITLE
Fix SQL injection in ExportAcitivity

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
@@ -156,6 +156,12 @@ public class ExportActivity extends AppCompatActivity implements ExportService.E
         setSupportActionBar(viewBinding.bottomAppBarLayout.bottomAppBar);
 
         directoryUri = getIntent().getParcelableExtra(EXTRA_DIRECTORY_URI_KEY);
+        // validity check
+        if (directoryUri == null || !"content".equals(directoryUri.getScheme())) {
+            Toast.makeText(this, "Invalid directory URI", Toast.LENGTH_SHORT).show();
+            finish(); // or return to prevent further execution
+            return;
+        }
         trackFileFormat = (TrackFileFormat) getIntent().getSerializableExtra(EXTRA_TRACKFILEFORMAT_KEY);
         boolean allInOneFile = getIntent().getBooleanExtra(EXTRA_ONE_FILE_KEY, false);
 

--- a/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/util/ExportUtils.java
@@ -85,7 +85,13 @@ public class ExportUtils {
     public static List<String> getAllFiles(Context context, Uri directoryUri) {
         List<String> fileNames = new ArrayList<>();
         final ContentResolver resolver = context.getContentResolver();
-        final Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(directoryUri, DocumentsContract.getDocumentId(directoryUri));
+        String docId = DocumentsContract.getDocumentId(directoryUri);
+
+        // Reject null, empty, or weird characters
+        if (docId == null || docId.trim().isEmpty() || docId.contains(";") || docId.contains("--")) {
+            throw new IllegalArgumentException("Invalid document ID");
+        }
+        final Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(directoryUri, docId);
 
         try (Cursor c = resolver.query(childrenUri, new String[]{DocumentsContract.Document.COLUMN_DISPLAY_NAME}, null, null, null)) {
             while (c.moveToNext()) {


### PR DESCRIPTION
**Solution Implemented:**

To mitigate SQL injection, two layers of validation are applied:

1. **URI Scheme Validation in ExportActivity.java**

Ensures that only URIs with the content:// scheme are allowed:

```java

if (directoryUri == null || !"content".equals(directoryUri.getScheme())) {
    Toast.makeText(this, "Invalid directory URI", Toast.LENGTH_SHORT).show();
    finish();
    return;
}
```

2. **Document ID Validation in ExportUtils.java**

Sanitizes the document ID extracted from the URI before it is used in a query:
```java

String docId = DocumentsContract.getDocumentId(directoryUri);

if (docId == null || docId.trim().isEmpty() || docId.contains(";") || docId.contains("--")) {
    throw new IllegalArgumentException("Invalid document ID");
}
```

This prevents injection patterns such as DROP TABLE or -- comment, which are commonly used in SQL injection attacks.


**Link to the Issue**: https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/93

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

