### PR TITLE
Fix exposed mutable array in SelectionData

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/SelectionData.java
+++ b/src/main/java/de/dennisguse/opentracks/data/SelectionData.java
@@ -4,12 +4,16 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public record SelectionData(
-    String selection,
-    String[] selectionArgs
+        String selection,
+        String[] selectionArgs
 ) {
-
     public SelectionData() {
         this(null, null);
+    }
+
+    @Override
+    public String[] selectionArgs() {
+        return selectionArgs == null ? null : selectionArgs.clone();
     }
 
     @Override


### PR DESCRIPTION
Description
This PR addresses a Malicious Code Vulnerability (EI_EXPOSE_REP) flagged by SpotBugs in the SelectionData class.
The method selectionArgs() was returning a direct reference to the internal mutable array selectionArgs, potentially exposing internal representation and violating encapsulation.

Fix Applied
Overrode selectionArgs() to return a defensive copy of the internal array using clone().

This ensures that anyone accessing selectionArgs() gets a copy, not the original internal array — which protects against malicious or accidental modifications.

File Modified
src/main/java/de/dennisguse/opentracks/data/SelectionData.java

Vulnerability Details
Vulnerability Type: Malicious Code Vulnerability (Exposed Internal Representation)

Issue: 107

<img width="1121" alt="image" src="https://github.com/user-attachments/assets/fdd53404-c73a-4637-8d74-68f7c036a05b" />

