### PR TITLE
Fix EI_EXPOSE_REP: Avoid exposing internal representation in getLastStoredTrackPointWithLocation()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,3 +186,4 @@ dependencies {
 
     androidTestUtil 'androidx.test:orchestrator:1.5.1'
 }
+

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingManager.java
@@ -285,9 +285,28 @@ public class TrackRecordingManager implements SharedPreferences.OnSharedPreferen
             idleDuration = PreferencesUtils.getIdleDurationTimeout();
         }
     }
+    private TrackPoint copyTrackPoint(TrackPoint source) {
+        if (source == null) return null;
+        TrackPoint copy = new TrackPoint(source.getType(), source.getTime());
+        copy.setId(source.getId());
+        copy.setLatitude(source.getLatitude());
+        copy.setLongitude(source.getLongitude());
+        copy.setHorizontalAccuracy(source.getHorizontalAccuracy());
+        copy.setVerticalAccuracy(source.getVerticalAccuracy());
+        copy.setAltitude(source.getAltitude());
+        copy.setSpeed(source.getSpeed());
+        copy.setBearing(source.getBearing());
+        copy.setSensorDistance(source.getSensorDistance());
+        copy.setHeartRate(source.getHeartRate());
+        copy.setCadence(source.getCadence());
+        copy.setPower(source.getPower());
+        copy.setAltitudeGain(source.hasAltitudeGain() ? source.getAltitudeGain() : null);
+        copy.setAltitudeLoss(source.hasAltitudeLoss() ? source.getAltitudeLoss() : null);
 
+        return copy;
+    }
     public TrackPoint getLastStoredTrackPointWithLocation() {
-        return lastStoredTrackPointWithLocation;
+        return copyTrackPoint(lastStoredTrackPointWithLocation);
     }
 
     public interface IdleObserver {


### PR DESCRIPTION
This PR addresses [Issue #120](https://github.com/SOEN6431Winter2025/OpenTracksW25/issues/120) by eliminating the exposure of internal mutable state from the TrackRecordingManager class.

Problem:
The method getLastStoredTrackPointWithLocation() was returning a direct reference to lastStoredTrackPointWithLocation, violating encapsulation and potentially allowing external modification of internal state.

Fix:
Introduced a private helper method copyTrackPoint() that returns a deep copy of a TrackPoint.

Modified getLastStoredTrackPointWithLocation() to return a defensive copy using this helper.

Why?
To ensure immutability of internal state and eliminate the SpotBugs EI_EXPOSE_REP warning.